### PR TITLE
feat: implement distance culling for skeletons to optimize rendering

### DIFF
--- a/Everest Plugin/Core/SkeletonManager.cs
+++ b/Everest Plugin/Core/SkeletonManager.cs
@@ -34,24 +34,12 @@ namespace Everest.Core
                 return;
             }
 
-            float closest = 0;
-            float furthest = 0;
-
             Vector3 camPos = cam.transform.position;
             for (int i = 0; i < skeletons.Length; i++)
             {
                 Vector3 skelPos = GetSkeletonVisualPosition(skeletons[i]);
                 float distance = Vector3.Distance(skelPos, camPos);
 
-                if (i == 0 || distance < closest)
-                {
-                    closest = distance;
-                }
-
-                if (i == 0 || distance >= furthest)
-                {
-                    furthest = distance;
-                }
                 if (distance > CULLING_DISTANCE)
                 {
                     skeletons[i].SetActive(false);
@@ -61,7 +49,6 @@ namespace Everest.Core
                     skeletons[i].SetActive(true);
                 }
             }
-            EverestPlugin.LogInfo($"Closest distance: {closest}. Furthest: {furthest}");
         }
 
         private Vector3 GetSkeletonVisualPosition(GameObject skeleton)


### PR DESCRIPTION
All this patch does render the skeletons based on distance. In this commit it's set to 150 units/150 meters? (I don't know Unity's rendering system), instead of rendering all the skeletons across the whole map. In my testing 150 units is a good distance to render most skeletons while you're climbing.