### PR TITLE
feat: implement distance culling for skeletons to optimize rendering, fix some oversights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+Everest.dll

--- a/Everest Editor/Everest Editor.csproj
+++ b/Everest Editor/Everest Editor.csproj
@@ -11,14 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\Everest Plugin\Accessories\FumoAccessory.cs" Link="FumoAccessory.cs" />
-    <Compile Include="..\Everest Plugin\Accessories\ShaderSwapper.cs" Link="ShaderSwapper.cs" />
-    <Compile Include="..\Everest Plugin\Accessories\SkeletonAccessory.cs" Link="SkeletonAccessory.cs" />
-    <Compile Include="..\Everest Plugin\Accessories\WilliamAccessory.cs" Link="WilliamAccessory.cs" />
-    <Compile Include="..\Everest Plugin\Core\Tombstone.cs" Link="Tombstone.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Reference Include="Unity.TextMeshPro">
       <HintPath>$(GameDir)\PEAK_Data\Managed\Unity.TextMeshPro.dll</HintPath>
     </Reference>
@@ -29,7 +21,7 @@
       <HintPath>$(GameDir)\PEAK_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\PEAK\PEAK_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>$(GameDir)\PEAK_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/Everest Plugin/Core/ConfigHandler.cs
+++ b/Everest Plugin/Core/ConfigHandler.cs
@@ -30,7 +30,7 @@ namespace Everest.Core
             enabled = config.Bind("General", "Enabled", true, "Enable or disable the Everest plugin.");
             numSkeletons = config.Bind("General", "MaxSkeletons", 100, "Number of skeletons to spawn.");
             allowUploads = config.Bind("General", "AllowUploads", true, "Allow uploading your own skeletons.");
-            cullingDistance = config.Bind("General", "CullingDistance", 150.0f, "The distance the skeletons will render at");
+            cullingDistance = config.Bind("General", "CullingDistance", 150.0f, "The maximum distance the skeletons will render at.");
             showToasts = config.Bind("UI", "ShowToasts", true, "Enable or disable toast notifications in the UI.");
 
             EverestPlugin.LogInfo("Configuration loaded successfully.");

--- a/Everest Plugin/Core/ConfigHandler.cs
+++ b/Everest Plugin/Core/ConfigHandler.cs
@@ -13,10 +13,14 @@ namespace Everest.Core
         private static ConfigEntry<bool> allowUploads;
         private static ConfigEntry<bool> showToasts;
 
+        private static ConfigEntry<float> cullingDistance;
+
         public static bool Enabled => enabled.Value;
         public static int MaxSkeletons => numSkeletons.Value;
         public static bool AllowUploads => allowUploads.Value;
         public static bool ShowToasts => showToasts.Value;
+
+        public static float CullingDistance => cullingDistance.Value;
 
 
         public static void Initialize()
@@ -26,11 +30,13 @@ namespace Everest.Core
             enabled = config.Bind("General", "Enabled", true, "Enable or disable the Everest plugin.");
             numSkeletons = config.Bind("General", "MaxSkeletons", 100, "Number of skeletons to spawn.");
             allowUploads = config.Bind("General", "AllowUploads", true, "Allow uploading your own skeletons.");
+            cullingDistance = config.Bind("General", "CullingDistance", 150.0f, "The distance the skeletons will render at");
             showToasts = config.Bind("UI", "ShowToasts", true, "Enable or disable toast notifications in the UI.");
 
             EverestPlugin.LogInfo("Configuration loaded successfully.");
             EverestPlugin.LogInfo($"Enabled: {Enabled}");
             EverestPlugin.LogInfo(message: $"Max Skeletons: {MaxSkeletons}");
+            EverestPlugin.LogInfo($"Culling distance: {CullingDistance}");
             EverestPlugin.LogInfo($"Allow Uploads: {AllowUploads}");
             EverestPlugin.LogInfo($"Show Toasts: {ShowToasts}");
 

--- a/Everest Plugin/Everest Plugin.csproj
+++ b/Everest Plugin/Everest Plugin.csproj
@@ -66,7 +66,7 @@
       <HintPath>$(GameDir)\PEAK_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\PEAK\PEAK_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>$(GameDir)\PEAK_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>$(GameDir)\PEAK_Data\Managed\UnityEngine.UI.dll</HintPath>

--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@ Everest is a mod for [PEAK](https://store.steampowered.com/app/3527290/PEAK/) th
 
 ![skeleton](https://github.com/user-attachments/assets/f1c7b164-2810-4e42-946a-b7a7e4f9706b)
 
-
 ## ✨ Features
 
-* **Shared Deaths:** Automatically uploads your death location to a central server.
-* **Persistent Skeletons:** Downloads the death locations of other players and spawns skeletons in their place, showing you where others have perished on their arduous climb to the top.
-* **UI Toasts:** Provides easy confirmation that the mod is working as expected and informs you when it isn't.
-* **Configurable:** A detailed configuration file lets you adjust the experience to your liking.
+- **Shared Deaths:** Automatically uploads your death location to a central server.
+- **Persistent Skeletons:** Downloads the death locations of other players and spawns skeletons in their place, showing you where others have perished on their arduous climb to the top.
+- **UI Toasts:** Provides easy confirmation that the mod is working as expected and informs you when it isn't.
+- **Configurable:** A detailed configuration file lets you adjust the experience to your liking.
 
 ---
 
@@ -18,9 +17,9 @@ Everest is a mod for [PEAK](https://store.steampowered.com/app/3527290/PEAK/) th
 
 Before installing Everest, please ensure you have the following installed:
 
-* **[BepInEx](https://github.com/BepInEx/BepInEx)**: The modding framework required to load the mod.
-* **[UniTask](https://github.com/Cysharp/UniTask)**: A library used to better handle async operations in Unity.
-  * Simply drop the UniTask dll files into `BepInEx/core` to install.
+- **[BepInEx](https://github.com/BepInEx/BepInEx)**: The modding framework required to load the mod.
+- **[UniTask](https://github.com/Cysharp/UniTask)**: A library used to better handle async operations in Unity.
+  - Simply drop the UniTask dll files into `BepInEx/core` to install.
 
 ---
 
@@ -39,25 +38,28 @@ The first time you run the game with Everest installed, it will generate a confi
 
 Here are the available options:
 
-* **`Enabled`**
-    * Toggles the entire mod on or off.
-    * **Values**: `true` / `false`
-    * **Default**: `true`
+- **`Enabled`**
 
-* **`MaxSkeletons`**
-    * Sets the maximum number of skeletons that can be spawned in your world at one time.
-    * **Values**: Any whole number (e.g., `10`, `25`, `50`)
-    * **Default**: `100`
+  - Toggles the entire mod on or off.
+  - **Values**: `true` / `false`
+  - **Default**: `true`
 
-* **`AllowUpload`**
-    * Determines if the mod will upload your own death location to the server. Set to `false` if you only want to see other players' skeletons without contributing your own.
-    * **Values**: `true` / `false`
-    * **Default**: `true`
+- **`MaxSkeletons`**
 
-* **`ShowToasts`**
-    * Enables or disables the small UI popups that notify you of mod activity (e.g., "Your death has been recorded" or "Skeletons have been summoned").
-    * **Values**: `true` / `false`
-    * **Default**: `true`
+  - Sets the maximum number of skeletons that can be spawned in your world at one time.
+  - **Values**: Any whole number (e.g., `10`, `25`, `50`)
+  - **Default**: `100`
+
+- **`AllowUpload`**
+
+  - Determines if the mod will upload your own death location to the server. Set to `false` if you only want to see other players' skeletons without contributing your own.
+  - **Values**: `true` / `false`
+  - **Default**: `true`
+
+- **`ShowToasts`**
+  - Enables or disables the small UI popups that notify you of mod activity (e.g., "Your death has been recorded" or "Skeletons have been summoned").
+  - **Values**: `true` / `false`
+  - **Default**: `true`
 
 ---
 
@@ -70,6 +72,7 @@ Clone the project, then create a file in the root of the project directory named
 Here you need to set the `GameDir` property to match your install directory.
 
 Example:
+
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
@@ -80,4 +83,18 @@ Example:
 </Project>
 ```
 
+Ensure you have the [.NET compiler installed](https://dotnet.microsoft.com/) (Tested with 9.0).
+
 Now when you build the mod, it should resolve your references automatically, and the build event will copy the plugin into your `BepInEx\plugins` folder!
+
+To build run
+
+```bash
+dotnet build
+```
+
+For a release build you can do
+
+```bash
+dotnet publish -c Release
+```


### PR DESCRIPTION
All this patch does render the skeletons based on distance. In this commit it's set to 150 units/150 meters? (I don't know Unity's rendering system), instead of rendering all the skeletons across the whole map. In my testing 150 units is a good distance to render most skeletons while you're climbing. You can change it in the Everest.cfg now as well.

I also fixed some configuration across .csproj files and added more documentation for developers.